### PR TITLE
Extended the wiringPiISR() function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ lib*.so.*
 debian-template/wiringPi
 debian-template/wiringpi-*.deb
 gpio/gpio
+.cproject
+.project

--- a/examples/isr-osc.c
+++ b/examples/isr-osc.c
@@ -95,7 +95,7 @@ int main (void)
   pinMode (OUT_PIN, OUTPUT) ;
   pinMode (IN_PIN,  INPUT) ;
 
-  if (wiringPiISR (IN_PIN, INT_EDGE_FALLING, &myInterrupt) < 0)
+  if (wiringPiISR (IN_PIN, INT_EDGE_FALLING, &myInterrupt, NULL) < 0)
   {
     fprintf (stderr, "Unable to setup ISR: %s\n", strerror (errno)) ;
     return 1 ;

--- a/examples/isr.c
+++ b/examples/isr.c
@@ -50,15 +50,11 @@ static volatile int globalCounter [8] ;
  *********************************************************************************
  */
 
-void myInterrupt0 (void) { ++globalCounter [0] ; }
-void myInterrupt1 (void) { ++globalCounter [1] ; }
-void myInterrupt2 (void) { ++globalCounter [2] ; }
-void myInterrupt3 (void) { ++globalCounter [3] ; }
-void myInterrupt4 (void) { ++globalCounter [4] ; }
-void myInterrupt5 (void) { ++globalCounter [5] ; }
-void myInterrupt6 (void) { ++globalCounter [6] ; }
-void myInterrupt7 (void) { ++globalCounter [7] ; }
-
+void myInterrupt (void* arg) 
+{
+  int* theCounter = (int*) arg;
+  ++(*theCounter);
+}
 
 /*
  *********************************************************************************
@@ -71,19 +67,13 @@ int main (void)
   int gotOne, pin ;
   int myCounter [8] ;
 
-  for (pin = 0 ; pin < 8 ; ++pin) 
-    globalCounter [pin] = myCounter [pin] = 0 ;
-
   wiringPiSetup () ;
 
-  wiringPiISR (0, INT_EDGE_FALLING, &myInterrupt0) ;
-  wiringPiISR (1, INT_EDGE_FALLING, &myInterrupt1) ;
-  wiringPiISR (2, INT_EDGE_FALLING, &myInterrupt2) ;
-  wiringPiISR (3, INT_EDGE_FALLING, &myInterrupt3) ;
-  wiringPiISR (4, INT_EDGE_FALLING, &myInterrupt4) ;
-  wiringPiISR (5, INT_EDGE_FALLING, &myInterrupt5) ;
-  wiringPiISR (6, INT_EDGE_FALLING, &myInterrupt6) ;
-  wiringPiISR (7, INT_EDGE_FALLING, &myInterrupt7) ;
+  for (pin = 0 ; pin < 8 ; ++pin) 
+  {
+    globalCounter [pin] = myCounter [pin] = 0 ;
+    wiringPiISR (pin, INT_EDGE_FALLING, &myInterrupt, &(globalCounter[pin])) ;
+  }
 
   for (;;)
   {

--- a/examples/lowPower.c
+++ b/examples/lowPower.c
@@ -40,7 +40,7 @@
  *********************************************************************************
  */
 
-void lowPower (void)
+void lowPower (void*)
 {
   time_t t ;
 
@@ -59,7 +59,7 @@ int main (void)
 {
   wiringPiSetupGpio () ;	// GPIO mode as it's an internal pin
 
-  wiringPiISR (LOW_POWER, INT_EDGE_FALLING, &lowPower) ;
+  wiringPiISR (LOW_POWER, INT_EDGE_FALLING, &lowPower, NULL) ;
 
   for (;;)
     delay (1000) ;

--- a/gpio/gpio.c
+++ b/gpio/gpio.c
@@ -543,7 +543,7 @@ void doExport (int argc, char *argv [])
  *********************************************************************************
  */
 
-static void wfi (void*)
+static void wfi (UNU void* arg)
   { exit (0) ; }
 
 void doWfi (int argc, char *argv [])

--- a/gpio/gpio.c
+++ b/gpio/gpio.c
@@ -543,7 +543,7 @@ void doExport (int argc, char *argv [])
  *********************************************************************************
  */
 
-static void wfi (void)
+static void wfi (void*)
   { exit (0) ; }
 
 void doWfi (int argc, char *argv [])
@@ -567,7 +567,7 @@ void doWfi (int argc, char *argv [])
     exit (1) ;
   }
 
-  if (wiringPiISR (pin, mode, &wfi) < 0)
+  if (wiringPiISR (pin, mode, &wfi, NULL) < 0)
   {
     fprintf (stderr, "%s: wfi: Unable to setup ISR: %s\n", argv [1], strerror (errno)) ;
     exit (1) ;

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -314,8 +314,7 @@ static int sysFds [64] =
 
 // ISR Data
 
-static void (*isrFunctions [64])(void) ;
-
+static void (*isrFunctions [64])(void*);
 
 // Doing it the Arduino way with lookup tables...
 //	Yes, it's probably more innefficient than all the bit-twidling, but it
@@ -1806,7 +1805,7 @@ int waitForInterrupt (int pin, int mS)
  *********************************************************************************
  */
 
-static void *interruptHandler (UNU void *arg)
+static void *interruptHandler (void *arg)
 {
   int myPin ;
 
@@ -1817,7 +1816,7 @@ static void *interruptHandler (UNU void *arg)
 
   for (;;)
     if (waitForInterrupt (myPin, -1) > 0)
-      isrFunctions [myPin] () ;
+      isrFunctions [myPin] (arg) ;
 
   return NULL ;
 }
@@ -1831,12 +1830,12 @@ static void *interruptHandler (UNU void *arg)
  *********************************************************************************
  */
 
-int wiringPiISR (int pin, int mode, void (*function)(void))
+int wiringPiISR (int pin, int mode, void (*function)(void*), void* functionParameter)
 {
   pthread_t threadId ;
   const char *modeS ;
   char fName   [64] ;
-  char  pinS [8] ;
+  char  pinS [8] ;Parameter
   pid_t pid ;
   int   count, i ;
   char  c ;
@@ -1913,7 +1912,7 @@ int wiringPiISR (int pin, int mode, void (*function)(void))
 
   pthread_mutex_lock (&pinMutex) ;
     pinPass = pin ;
-    pthread_create (&threadId, NULL, interruptHandler, NULL) ;
+    pthread_create (&threadId, NULL, interruptHandler, functionParameter) ;
     while (pinPass != -1)
       delay (1) ;
   pthread_mutex_unlock (&pinMutex) ;

--- a/wiringPi/wiringPi.c
+++ b/wiringPi/wiringPi.c
@@ -1835,7 +1835,7 @@ int wiringPiISR (int pin, int mode, void (*function)(void*), void* functionParam
   pthread_t threadId ;
   const char *modeS ;
   char fName   [64] ;
-  char  pinS [8] ;Parameter
+  char  pinS [8] ;
   pid_t pid ;
   int   count, i ;
   char  c ;

--- a/wiringPi/wiringPi.h
+++ b/wiringPi/wiringPi.h
@@ -215,7 +215,7 @@ extern          void gpioClockSet        (int pin, int freq) ;
 //	(Also Pi hardware specific)
 
 extern int  waitForInterrupt    (int pin, int mS) ;
-extern int  wiringPiISR         (int pin, int mode, void (*function)(void)) ;
+extern int  wiringPiISR         (int pin, int mode, void (*function)(void*), void* functionParameter) ;
 
 // Threads
 


### PR DESCRIPTION
It is often useful, if the function that gets called to handle an occurred interrupt, can be passed
user defined data, such as a pointer to a data structure or a counter.
Since the ISR is internally handled by a pthread that provides an void* pointer as argument to the
created pthread function anyway - this adds almost no overhead.
Example given in examples/isr.c: wiringPiISR is called on 8 pins and every call uses the same
function but a different pointer to an integer counter is provided.